### PR TITLE
docs: copy paste docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Gemfile.lock
 
 # junit reports folder
 spec/junit-reports
+
+# Doc build files
+html_docs

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,0 +1,16 @@
+:ecs-repo-dir:  {ecs-logging-root}/docs/
+
+include::{docs-root}/shared/versions/stack/current.asciidoc[]
+include::{docs-root}/shared/attributes.asciidoc[]
+
+ifdef::env-github[]
+NOTE: For the best reading experience,
+please view this documentation at https://www.elastic.co/guide/en/ecs-logging/ruby/current/index.html[elastic.co]
+endif::[]
+
+= ECS Logging Ruby Reference
+
+ifndef::env-github[]
+include::./intro.asciidoc[Introduction]
+include::./setup.asciidoc[Set up]
+endif::[]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -1,0 +1,10 @@
+[[intro]]
+== Introduction
+
+ECS loggers are formatter/encoder plugins for your favorite logging libraries.
+They make it easy to format your logs into ECS-compatible JSON.
+
+TIP: Want to learn more about ECS, ECS logging, and other available language plugins?
+See the {ecs-logging-ref}/intro.html[ECS logging guide].
+
+Ready to jump into `ecs-logging-ruby`? <<setup,Get started>>.

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -1,0 +1,147 @@
+[[setup]]
+== Get started
+
+include::./tab-widgets/code.asciidoc[]
+
+[float]
+[[setup-step-1]]
+=== Step 1: Set up application logging
+
+[float]
+==== Add the dependency
+
+Add this line to your application's Gemfile:
+
+[source,ruby]
+----
+gem 'ecs-logging'
+----
+
+Execute with:
+
+[source,cmd]
+----
+bundle install
+----
+
+Alternatively, you can install the package yourself with:
+
+[source,cmd]
+----
+gem install ecs-logging
+----
+
+[float]
+==== Configure
+
+`Ecs::Logger` is a subclass of Ruby's own https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html[`Logger`]
+and responds to the same methods.
+
+For example:
+
+[source,ruby]
+----
+require 'ecs/logger'
+
+logger = Ecs::Logger.new($stdout)
+logger.info('my informative message')
+logger.warn { 'be aware that…' }
+logger.error('a_progname') { 'oh no!' }
+----
+
+Logs the following JSON to `$stdout`:
+
+[source,json]
+----
+{"@timestamp":"2020-11-24T13:32:21.329Z","log.level":"INFO","message":"very informative","ecs.version":"1.4.0"}
+ {"@timestamp":"2020-11-24T13:32:21.330Z","log.level":"WARN","message":"be aware that…","ecs.version":"1.4.0"}
+ {"@timestamp":"2020-11-24T13:32:21.331Z","log.level":"ERROR","message":"oh no!","ecs.version":"1.4.0","process.title":"a_progname"}
+----
+
+Additionally, it allows for adding additional keys to messages.
+
+For example:
+
+[source,ruby]
+----
+logger.info('ok', labels: { my_label: 'value' }, 'trace.id': 'abc-xyz')
+----
+
+Logs the following:
+
+[source,json]
+----
+{
+  "@timestamp":"2020-11-24T13:32:21.331Z",
+  "log.level":"ERROR",
+  "message":"oh no!",
+  "ecs.version":"1.4.0",
+  "labels":{"my_label":"value"},
+  "trace.id":"abc-xyz"
+}
+----
+
+To include info about where the log was called, call the methods with `include_origin: true`,
+like `logger.warn('Hello!', include_origin: true)`. This logs:
+
+[source,json]
+----
+{
+  "@timestamp":"2020-11-24T13:32:21.331Z",
+  "log.level":"WARN",
+  "message":"Hello!",
+  "ecs.version":"1.4.0",
+  "log.origin": {
+    "file.line": 123,
+    "file.name": "my_file.rb",
+    "function": "call"
+  }
+}
+----
+
+[float]
+==== Rack configuration
+
+[source,ruby]
+----
+use EcsLogging::Middleware, $stdout
+----
+
+Example output:
+
+[source,json]
+----
+{
+  "@timestamp":"2020-12-07T13:44:04.568Z",
+  "log.level":"INFO",
+  "message":"GET /",
+  "ecs.version":"1.4.0",
+  "client":{
+    "address":"127.0.0.1"
+  },
+  "http":{
+    "request":{
+      "method":"GET",
+      "body.bytes":"0"
+    }
+  },
+  "url":{
+    "domain":"example.org",
+    "path":"/",
+    "port":"80",
+    "scheme":"http"
+  }
+}
+----
+
+[float]
+[[setup-step-2]]
+=== Step 2: Enable APM log correlation (optional)
+If you are using the Elastic APM Ruby agent,
+{apm-ruby-ref}/log-correlation.html[enable log correlation].
+
+[float]
+[[setup-step-3]]
+=== Step 3: Configure Filebeat
+
+include::{ecs-repo-dir}/setup.asciidoc[tag=configure-filebeat]


### PR DESCRIPTION
### Summary

This PR adds `ecs-logging-ruby` docs. Shared content is included from the `ecs-logging` repo.

To test this PR, you'll need an up-to-date copy of both [`elastic/docs`](https://github.com/elastic/docs) and [`elastic/ecs-logging`](https://github.com/elastic/ecs-logging). Then run the following command, where `$GIT_HOME` is the path to your local repos:

```
$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-ruby/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1 --open
```

### Follow-ups

- [ ] Open PR in elastic/docs to add to the build
- [ ] Open infra ticket to add the docs check to this repo
- [ ] Add webhook for docs check
- [ ] Remove content from readme and link to docs

