### PR TITLE
synchronize ecs-logging spec

### DIFF
--- a/spec/fixtures/spec/spec.json
+++ b/spec/fixtures/spec/spec.json
@@ -1,135 +1,175 @@
 {
-  "version": 1.0,
-  "url": "https://www.elastic.co/guide/en/ecs/current/index.html",
-  "ecs": {
-    "version": "1.x"
-  },
-  "fields": {
-    "@timestamp": {
-      "type": "datetime",
-      "required": true,
-      "index": 0,
-      "url": "https://www.elastic.co/guide/en/ecs/current/ecs-base.html"
+    "version": 1.0,
+    "url": "https://www.elastic.co/guide/en/ecs/current/index.html",
+    "ecs": {
+        "version": "1.x"
     },
-    "log.level": {
-      "type": "string",
-      "required": true,
-      "index": 1,
-      "top_level_field": true,
-      "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html",
-      "comment": [
-        "This field SHOULD NOT be a nested object field but at the top level with a dot in the property name.",
-        "This is to make the JSON logs more human-readable.",
-        "Loggers MAY indent the log level so that the `message` field always starts at the exact same offset,",
-        "no matter the number of characters the log level has.",
-        "For example: `'DEBUG'` (5 chars) will not be indented, whereas ` 'WARN'` (4 chars) will be indented by one space character."
-        ]
-    },
-    "message": {
-      "type": "string",
-      "required": true,
-      "index": 2,
-      "url": "https://www.elastic.co/guide/en/ecs/current/ecs-base.html"
-    },
-    "ecs.version": {
-      "type": "string",
-      "required": true,
-      "url": "https://www.elastic.co/guide/en/ecs/current/ecs-ecs.html"
-    },
-    "labels": {
-      "type": "object",
-      "required": false,
-      "url": "https://www.elastic.co/guide/en/ecs/current/ecs-base.html",
-      "sanitization": {
-        "key": {
-          "replacements": [".", "*", "\\"],
-          "substitute": "_"
+    "fields": {
+        "@timestamp": {
+            "type": "datetime",
+            "required": true,
+            "index": 0,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-base.html",
+            "comment": [
+                "Field order, as specified by 'index', is RECOMMENDED.",
+                "ECS loggers must implement field order unless the logging framework makes that impossible."
+            ]
+        },
+        "log.level": {
+            "type": "string",
+            "required": true,
+            "index": 1,
+            "top_level_field": true,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html",
+            "comment": [
+                "This field SHOULD NOT be a nested object field but at the top level with a dot in the property name.",
+                "This is to make the JSON logs more human-readable.",
+                "Loggers MAY indent the log level so that the `message` field always starts at the exact same offset,",
+                "no matter the number of characters the log level has.",
+                "For example: `'DEBUG'` (5 chars) will not be indented, whereas ` 'WARN'` (4 chars) will be indented by one space character."
+            ]
+        },
+        "message": {
+            "type": "string",
+            "required": false,
+            "index": 2,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-base.html",
+            "comment": [
+                "A message field is typically included in all log records, but some logging libraries allow records with no message.",
+                "That's typically the case for libraries that allow for structured logging."
+            ]
+        },
+        "ecs.version": {
+            "type": "string",
+            "required": true,
+            "top_level_field": true,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-ecs.html",
+            "comment": [
+                "This field SHOULD NOT be a nested object field but at the top level with a dot in the property name.",
+                "This is to make the JSON logs more human-readable."
+            ]
+        },
+        "labels": {
+            "type": "object",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-base.html",
+            "sanitization": {
+                "key": {
+                    "replacements": [".", "*", "\\"],
+                    "substitute": "_"
+                }
+            }
+        },
+        "trace.id": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html",
+            "comment": "When APM agents add this field to the context, ecs loggers should pick it up and add it to the log event."
+        },
+        "transaction.id": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html",
+            "comment": "When APM agents add this field to the context, ecs loggers should pick it up and add it to the log event."
+        },
+        "service.name": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html",
+            "comment": [
+                "Configurable by users.",
+                "When an APM agent is active, it should auto-configure this field if not already set."
+            ]
+        },
+        "service.node.name": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html",
+            "comment": [
+                "Configurable by users.",
+                "When an APM agent is active and `service_node_name` is manually configured, the agent should auto-configure this field if not already set."
+            ]
+        },
+        "service.version": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html#field-service-version",
+            "comment": [
+                "Configurable by users.",
+                "When an APM agent is active, it should auto-configure it if not already set."
+            ]
+        },
+        "event.dataset": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-event.html",
+            "default": "${service.name} OR ${service.name}.${appender.name}",
+            "comment": [
+                "Configurable by users.",
+                "If the user manually configures the service name,",
+                "the logging library should set `event.dataset=${service.name}` if not explicitly configured otherwise.",
+                "",
+                "When agents auto-configure the app to use an ECS logger,",
+                "they should set `event.dataset=${service.name}.${appender.name}` if the appender name is available in the logging library.",
+                "Otherwise, agents should also set `event.dataset=${service.name}`",
+                "",
+                "The field helps to filter for different log streams from the same pod, for example and is required for log anomaly detection."
+            ]
+        },
+        "service.environment": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html#field-service-environment",
+            "comment": [
+                "Configurable by users.",
+                "When an APM agent is active, it should auto-configure it if not already set."
+            ]
+        },
+        "process.thread.name": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-process.html"
+        },
+        "log.logger": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html"
+        },
+        "log.origin.file.line": {
+            "type": "integer",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html",
+            "comment": "Should be opt-in as it requires the logging library to capture a stack trace for each log event."
+        },
+        "log.origin.file.name": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html",
+            "comment": "Should be opt-in as it requires the logging library to capture a stack trace for each log event."
+        },
+        "log.origin.function": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html",
+            "comment": "Should be opt-in as it requires the logging library to capture a stack trace for each log event."
+        },
+        "error.type": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-error.html",
+            "comment": "The exception type or class, such as `java.lang.IllegalArgumentException`."
+        },
+        "error.message": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-error.html",
+            "comment": "The message of the exception."
+        },
+        "error.stack_trace": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-error.html",
+            "comment": "The stack trace of the exception as plain text."
         }
-      }
-    },
-    "trace.id": {
-      "type": "string",
-      "required": false,
-      "url": "https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html",
-      "comment": "When APM agents add this field to the context, ecs loggers should pick it up and add it to the log event."
-    },
-    "transaction.id": {
-      "type": "string",
-      "required": false,
-      "url": "https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html",
-      "comment": "When APM agents add this field to the context, ecs loggers should pick it up and add it to the log event."
-    },
-    "service.name": {
-      "type": "string",
-      "required": false,
-      "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html",
-      "comment": [
-        "Configurable by users.",
-        "When an APM agent is active, they should auto-configure it if not already set."
-      ]
-    },
-    "event.dataset": {
-      "type": "string",
-      "required": false,
-      "url": "https://www.elastic.co/guide/en/ecs/current/ecs-event.html",
-      "default": "${service.name}.log OR ${service.name}.${appender.name}",
-      "comment": [
-        "Configurable by users.",
-        "If the user manually configures the service name,",
-        "the logging library should set `event.dataset=${service.name}.log` if not explicitly configured otherwise.",
-        "",
-        "When agents auto-configure the app to use an ECS logger,",
-        "they should set `event.dataset=${service.name}.${appender.name}` if the appender name is available in the logging library.",
-        "Otherwise, agents should also set `event.dataset=${service.name}.log`",
-        "",
-        "The field helps to filter for different log streams from the same pod, for example and is required for log anomaly detection."
-      ]
-    },
-    "process.thread.name": {
-      "type": "string",
-      "required": false,
-      "url": "https://www.elastic.co/guide/en/ecs/current/ecs-process.html"
-    },
-    "log.logger": {
-      "type": "string",
-      "required": false,
-      "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html"
-    },
-    "log.origin.file.line": {
-      "type": "integer",
-      "required": false,
-      "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html",
-      "comment": "Should be opt-in as it requires the logging library to capture a stack trace for each log event."
-    },
-    "log.origin.file.name": {
-      "type": "string",
-      "required": false,
-      "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html",
-      "comment": "Should be opt-in as it requires the logging library to capture a stack trace for each log event."
-    },
-    "log.origin.function": {
-      "type": "string",
-      "required": false,
-      "url": "https://www.elastic.co/guide/en/ecs/current/ecs-log.html",
-      "comment": "Should be opt-in as it requires the logging library to capture a stack trace for each log event."
-    },
-    "error.type": {
-      "type": "string",
-      "required": false,
-      "url": "https://www.elastic.co/guide/en/ecs/current/ecs-error.html",
-      "comment": "The exception type or class, such as `java.lang.IllegalArgumentException`."
-    },
-    "error.message": {
-      "type": "string",
-      "required": false,
-      "url": "https://www.elastic.co/guide/en/ecs/current/ecs-error.html",
-      "comment": "The message of the exception."
-    },
-    "error.stack_trace": {
-      "type": "string",
-      "required": false,
-      "url": "https://www.elastic.co/guide/en/ecs/current/ecs-error.html",
-      "comment": "The stack trace of the exception as plain text."
     }
-  }
 }


### PR DESCRIPTION


### What

ECS logging specs automatic sync

### Why

*Changeset*
* https://github.com/elastic/ecs-logging/commit/438fc2cff8edac7595aead6346b8df22b7d23b2b

---



<Actions>
    <action id="072d2eed95c7fd7b9f01e26f59fd9e06738a6ba4ba8d0a25861713cf87c4de2a">
        <h3>update specs</h3>
        <details id="598845be89fab97dcaf0fe62a6c09d78401a1e112a4d7560bc39500f9e2cc002">
            <summary>synchronize ecs-logging spec</summary>
            <p>1 file(s) updated with &#34;{\n    \&#34;version\&#34;: 1.0,\n    \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/index.html\&#34;,\n    \&#34;ecs\&#34;: {\n        \&#34;version\&#34;: \&#34;1.x\&#34;\n    },\n    \&#34;fields\&#34;: {\n        \&#34;@timestamp\&#34;: {\n            \&#34;type\&#34;: \&#34;datetime\&#34;,\n            \&#34;required\&#34;: true,\n            \&#34;index\&#34;: 0,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-base.html\&#34;,\n            \&#34;comment\&#34;: [\n                \&#34;Field order, as specified by &#39;index&#39;, is RECOMMENDED.\&#34;,\n                \&#34;ECS loggers must implement field order unless the logging framework makes that impossible.\&#34;\n            ]\n        },\n        \&#34;log.level\&#34;: {\n            \&#34;type\&#34;: \&#34;string\&#34;,\n            \&#34;required\&#34;: true,\n            \&#34;index\&#34;: 1,\n            \&#34;top_level_field\&#34;: true,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-log.html\&#34;,\n            \&#34;comment\&#34;: [\n                \&#34;This field SHOULD NOT be a nested object field but at the top level with a dot in the property name.\&#34;,\n                \&#34;This is to make the JSON logs more human-readable.\&#34;,\n                \&#34;Loggers MAY indent the log level so that the `message` field always starts at the exact same offset,\&#34;,\n                \&#34;no matter the number of characters the log level has.\&#34;,\n                \&#34;For example: `&#39;DEBUG&#39;` (5 chars) will not be indented, whereas ` &#39;WARN&#39;` (4 chars) will be indented by one space character.\&#34;\n            ]\n        },\n        \&#34;message\&#34;: {\n            \&#34;type\&#34;: \&#34;string\&#34;,\n            \&#34;required\&#34;: false,\n            \&#34;index\&#34;: 2,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-base.html\&#34;,\n            \&#34;comment\&#34;: [\n                \&#34;A message field is typically included in all log records, but some logging libraries allow records with no message.\&#34;,\n                \&#34;That&#39;s typically the case for libraries that allow for structured logging.\&#34;\n            ]\n        },\n        \&#34;ecs.version\&#34;: {\n            \&#34;type\&#34;: \&#34;string\&#34;,\n            \&#34;required\&#34;: true,\n            \&#34;top_level_field\&#34;: true,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-ecs.html\&#34;,\n            \&#34;comment\&#34;: [\n                \&#34;This field SHOULD NOT be a nested object field but at the top level with a dot in the property name.\&#34;,\n                \&#34;This is to make the JSON logs more human-readable.\&#34;\n            ]\n        },\n        \&#34;labels\&#34;: {\n            \&#34;type\&#34;: \&#34;object\&#34;,\n            \&#34;required\&#34;: false,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-base.html\&#34;,\n            \&#34;sanitization\&#34;: {\n                \&#34;key\&#34;: {\n                    \&#34;replacements\&#34;: [\&#34;.\&#34;, \&#34;*\&#34;, \&#34;\\\\\&#34;],\n                    \&#34;substitute\&#34;: \&#34;_\&#34;\n                }\n            }\n        },\n        \&#34;trace.id\&#34;: {\n            \&#34;type\&#34;: \&#34;string\&#34;,\n            \&#34;required\&#34;: false,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html\&#34;,\n            \&#34;comment\&#34;: \&#34;When APM agents add this field to the context, ecs loggers should pick it up and add it to the log event.\&#34;\n        },\n        \&#34;transaction.id\&#34;: {\n            \&#34;type\&#34;: \&#34;string\&#34;,\n            \&#34;required\&#34;: false,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html\&#34;,\n            \&#34;comment\&#34;: \&#34;When APM agents add this field to the context, ecs loggers should pick it up and add it to the log event.\&#34;\n        },\n        \&#34;service.name\&#34;: {\n            \&#34;type\&#34;: \&#34;string\&#34;,\n            \&#34;required\&#34;: false,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-service.html\&#34;,\n            \&#34;comment\&#34;: [\n                \&#34;Configurable by users.\&#34;,\n                \&#34;When an APM agent is active, it should auto-configure this field if not already set.\&#34;\n            ]\n        },\n        \&#34;service.node.name\&#34;: {\n            \&#34;type\&#34;: \&#34;string\&#34;,\n            \&#34;required\&#34;: false,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-service.html\&#34;,\n            \&#34;comment\&#34;: [\n                \&#34;Configurable by users.\&#34;,\n                \&#34;When an APM agent is active and `service_node_name` is manually configured, the agent should auto-configure this field if not already set.\&#34;\n            ]\n        },\n        \&#34;service.version\&#34;: {\n            \&#34;type\&#34;: \&#34;string\&#34;,\n            \&#34;required\&#34;: false,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-service.html#field-service-version\&#34;,\n            \&#34;comment\&#34;: [\n                \&#34;Configurable by users.\&#34;,\n                \&#34;When an APM agent is active, it should auto-configure it if not already set.\&#34;\n            ]\n        },\n        \&#34;event.dataset\&#34;: {\n            \&#34;type\&#34;: \&#34;string\&#34;,\n            \&#34;required\&#34;: false,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-event.html\&#34;,\n            \&#34;default\&#34;: \&#34;${service.name} OR ${service.name}.${appender.name}\&#34;,\n            \&#34;comment\&#34;: [\n                \&#34;Configurable by users.\&#34;,\n                \&#34;If the user manually configures the service name,\&#34;,\n                \&#34;the logging library should set `event.dataset=${service.name}` if not explicitly configured otherwise.\&#34;,\n                \&#34;\&#34;,\n                \&#34;When agents auto-configure the app to use an ECS logger,\&#34;,\n                \&#34;they should set `event.dataset=${service.name}.${appender.name}` if the appender name is available in the logging library.\&#34;,\n                \&#34;Otherwise, agents should also set `event.dataset=${service.name}`\&#34;,\n                \&#34;\&#34;,\n                \&#34;The field helps to filter for different log streams from the same pod, for example and is required for log anomaly detection.\&#34;\n            ]\n        },\n        \&#34;service.environment\&#34;: {\n            \&#34;type\&#34;: \&#34;string\&#34;,\n            \&#34;required\&#34;: false,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-service.html#field-service-environment\&#34;,\n            \&#34;comment\&#34;: [\n                \&#34;Configurable by users.\&#34;,\n                \&#34;When an APM agent is active, it should auto-configure it if not already set.\&#34;\n            ]\n        },\n        \&#34;process.thread.name\&#34;: {\n            \&#34;type\&#34;: \&#34;string\&#34;,\n            \&#34;required\&#34;: false,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-process.html\&#34;\n        },\n        \&#34;log.logger\&#34;: {\n            \&#34;type\&#34;: \&#34;string\&#34;,\n            \&#34;required\&#34;: false,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-log.html\&#34;\n        },\n        \&#34;log.origin.file.line\&#34;: {\n            \&#34;type\&#34;: \&#34;integer\&#34;,\n            \&#34;required\&#34;: false,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-log.html\&#34;,\n            \&#34;comment\&#34;: \&#34;Should be opt-in as it requires the logging library to capture a stack trace for each log event.\&#34;\n        },\n        \&#34;log.origin.file.name\&#34;: {\n            \&#34;type\&#34;: \&#34;string\&#34;,\n            \&#34;required\&#34;: false,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-log.html\&#34;,\n            \&#34;comment\&#34;: \&#34;Should be opt-in as it requires the logging library to capture a stack trace for each log event.\&#34;\n        },\n        \&#34;log.origin.function\&#34;: {\n            \&#34;type\&#34;: \&#34;string\&#34;,\n            \&#34;required\&#34;: false,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-log.html\&#34;,\n            \&#34;comment\&#34;: \&#34;Should be opt-in as it requires the logging library to capture a stack trace for each log event.\&#34;\n        },\n        \&#34;error.type\&#34;: {\n            \&#34;type\&#34;: \&#34;string\&#34;,\n            \&#34;required\&#34;: false,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-error.html\&#34;,\n            \&#34;comment\&#34;: \&#34;The exception type or class, such as `java.lang.IllegalArgumentException`.\&#34;\n        },\n        \&#34;error.message\&#34;: {\n            \&#34;type\&#34;: \&#34;string\&#34;,\n            \&#34;required\&#34;: false,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-error.html\&#34;,\n            \&#34;comment\&#34;: \&#34;The message of the exception.\&#34;\n        },\n        \&#34;error.stack_trace\&#34;: {\n            \&#34;type\&#34;: \&#34;string\&#34;,\n            \&#34;required\&#34;: false,\n            \&#34;url\&#34;: \&#34;https://www.elastic.co/guide/en/ecs/current/ecs-error.html\&#34;,\n            \&#34;comment\&#34;: \&#34;The stack trace of the exception as plain text.\&#34;\n        }\n    }\n}\n&#34;:&#xA;&#x9;* spec/fixtures/spec/spec.json&#xA;</p>
        </details>
        <a href="https://github.com/elastic/ecs-logging-ruby/actions/runs/9554572990">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

