### PR TITLE
github-actions: Migrate from docker-compose v1 to docker compose v2

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -58,7 +58,7 @@ def run(cmd)
 end
 
 unless options[:skip_build]
-  run 'docker-compose build ' \
+  run 'docker compose build ' \
     " --build-arg RUBY_IMAGE=#{RUBY_IMAGE}" \
     " --build-arg USER_ID_GROUP=#{USER_ID_GROUP}" \
     " --build-arg FRAMEWORKS=#{FRAMEWORKS}" \
@@ -66,7 +66,7 @@ unless options[:skip_build]
   exit $?.exitstatus unless $?.success?
 end
 
-run 'docker-compose run' \
+run 'docker compose run' \
   ' --rm' \
   " specs #{ARGV.join}"
 


### PR DESCRIPTION
## What

Update usages of `docker-compose` to `docker compose`.

## Why

https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/

and we got alerted by the log `docker-compose: command not found` at https://github.com/elastic/ecs-logging-ruby/actions/runs/10365823940/job/28693752765?pr=49

## Refs
- https://docs.docker.com/compose/migrate/
- https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/