### PR TITLE
Bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,15 @@ jobs:
         env:
           RUBY_VERSION: ${{ matrix.ruby-image }}
         run: bin/dev --image=${{ matrix.ruby-image }} --frameworks=${{ matrix.framework }}
+      - name: prepare artifact name # because it cannot have colons ":"
+        id: artifact_name
+        run: |
+          echo "artifact_name="test-results-${RUBY_IMAGE//:/_}-${FRAMEWORK}" >> "${GITHUB_OUTPUT}"
+        env:
+          RUBY_IMAGE: ${{ matrix.ruby-image }}
+          FRAMEWORK: ${{ matrix.framework }}
       - uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
-          name: test-results-${{ matrix.ruby-image }}-${{ matrix.framework }}
+          name: ${{ steps.artifact_name.outputs.artifact_name }}
           path: 'spec/junit-reports/**/*-junit.xml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: prepare artifact name # because it cannot have colons ":"
         id: artifact_name
         run: |
-          echo "artifact_name="test-results-${RUBY_IMAGE//:/_}-${FRAMEWORK}" >> "${GITHUB_OUTPUT}"
+          echo "artifact_name=test-results-${RUBY_IMAGE//:/_}-${FRAMEWORK}" >> "${GITHUB_OUTPUT}"
         env:
           RUBY_IMAGE: ${{ matrix.ruby-image }}
           FRAMEWORK: ${{ matrix.framework }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,8 @@ jobs:
         env:
           RUBY_VERSION: ${{ matrix.ruby-image }}
         run: bin/dev --image=${{ matrix.ruby-image }} --frameworks=${{ matrix.framework }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
-          name: test-results
+          name: test-results-${{ matrix.ruby-image }}-${{ matrix.framework }}
           path: 'spec/junit-reports/**/*-junit.xml'


### PR DESCRIPTION
This will upload one artifact for each matrix item.

In a follow-up, we can fix the test-reporter to match the pattern `test-results-*`