### PR TITLE
Update test-reporter workflow

### DIFF
--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -17,9 +17,9 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-      - uses: elastic/apm-pipeline-library/.github/actions/test-report@current
+      - uses: elastic/oblt-actions/test-report@v1
         with:
-          artifact: test-results
-          name: Test Report
+          artifact: /test-results(.*)/
+          name: 'Test Report $1'
           path: "spec/junit-reports/**/*-junit.xml"
           reporter: java-junit


### PR DESCRIPTION
This can be updated and re-enabled since https://github.com/elastic/ecs-logging-ruby/pull/54