### PR TITLE
[docs] Add `products` to `docset.yml`

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -1,4 +1,6 @@
 project: 'ECS Logging Ruby'
+products:
+  id: ecs-logging
 cross_links:
   - apm-agent-ruby
   - beats

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -1,6 +1,6 @@
 project: 'ECS Logging Ruby'
 products:
-  id: ecs-logging
+  - id: ecs-logging
 cross_links:
   - apm-agent-ruby
   - beats


### PR DESCRIPTION
Related to https://github.com/elastic/docs-builder/issues/1200

Add `products` to `docset.yml` to be used in the search experience.

cc @KOTungseth 