### PR TITLE
docs: add `applies_to` tags for docs versioning (cumulative docs)

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,7 +1,12 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/ruby/current/intro.html
   - https://www.elastic.co/guide/en/ecs-logging/ruby/current/index.html
+products:
+  - id: ecs-logging
 ---
 
 # ECS Logging Ruby [intro]

--- a/docs/reference/setup.md
+++ b/docs/reference/setup.md
@@ -1,7 +1,12 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/ruby/current/setup.html
 navigation_title: Get started
+products:
+  - id: ecs-logging
 ---
 
 # Get started with ECS Logging Ruby [setup]
@@ -131,6 +136,11 @@ If you are using the Elastic APM Ruby agent, [enable log correlation](apm-agent-
 
 
 ## Step 3: Configure Filebeat [setup-step-3]
+
+```{applies_to}
+stack: ga
+serverless: unavailable
+```
 
 :::::::{tab-set}
 


### PR DESCRIPTION
## Summary

Adds mandatory `applies_to` frontmatter to the reference docs so they comply with the [Docs Versioning contributor guidelines](https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs) and the [docs-builder applies_to syntax](https://elastic.github.io/docs-builder/syntax/applies/).

Relates to [#256](https://github.com/elastic/docs-content-internal/issues/256)

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Claude Sonnet 4.5 using Cursor to double-check the updated files, write PR description